### PR TITLE
Fixed p7zip crash

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
 12.12	Added: Upload script to submit results
-	Modified: Renamed script to linux-bench.sh
+		Modified: Renamed script to linux-bench.sh
+		Fixed: p7zip make command caused p7zip to hang, had a hanging -j
 12.11 	Modified: Moved all installers into new install routine and localized the install.
 		Fixed: Redis - cleaned up logic to make it run, reduced	iterations to improve speed
 		Modified: Cleaned up script to toally remove PTS

--- a/linux-bench.sh
+++ b/linux-bench.sh
@@ -524,7 +524,7 @@ p7zip()
 
 	echo "Building p7zip"
 	cd $appbase
-	make -j 2>&1 >> /dev/null
+	make 2>&1 >> /dev/null
 
 	echo "Starting 7zip benchmark, this will take a while"
 	bin/7za b >> output.txt


### PR DESCRIPTION
Resolves #37, this was due to a parallel make (make -j) without limiting number of cores. p7zip is infinitely parallel so it overloads the CPU. This is now a serial build so will take longer.
