### PR TITLE
Added fix to correct issue specifically with Ubuntu 16.0.4 installing…

### DIFF
--- a/linux-bench.sh
+++ b/linux-bench.sh
@@ -115,7 +115,7 @@ setup()
 Update_Install_Debian()
 {
 	apt-get update
-	apt-get -y install build-essential libx11-dev libglu-dev hardinfo sysbench unzip expect php5-curl php5-common php5-cli php5-gd libfpdi-php gfortran curl
+	apt-get -y install build-essential libx11-dev libglu-dev hardinfo sysbench unzip expect php-curl php-common php-cli php-gd libfpdi-php gfortran curl binutils
 	mkdir -p /usr/tmp/
 	rm /etc/apt/sources.list.d/linuxbench.list
 }


### PR DESCRIPTION
… php5 which isn't found in the repo.

I tested on a clean install of Ubuntu server 16.04.1 LTS and the script did detected this OS but as you mentioned dependencies were incorrect for php because php5 isn't found in that repo and thereby skipped installing them all.  

I updated the list of packages that install correctly for 16.04.1 but does this script need to maintain backward compatibility for older Ubuntu/Debian when the function named "Update_Install_Debian" is run?  If so reject this and I'll make it smarter to detect 16.04.

Note binutils added to dependencies to fix issue with line 237 [eval "strings `which lscpu`" | grep -q version ;]
